### PR TITLE
Image encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ vs = VisionStack(
                 UnderWaterImageEnhancementLayer(), # Uses a generative AI model to improve underwater images (good for murky waters).
                 # Include as many layers in any combination as you need
             ],
+            unique_name="some_name_here" # part of topic name
         )
 
 # Pass image through vision stack
@@ -58,7 +59,7 @@ img = img.convert('RGB')
 img_array = np.array(img)
 
 # Pass img_array through vision_stack
-vs.run(in_image = image_array, verbose = True)
+vs.run(in_image = img_array, verbose = True)
 # With verbose, if ros is running then topics will be created for each layer to visualize processing.
 ```
 

--- a/vision_stack/VisionStack.py
+++ b/vision_stack/VisionStack.py
@@ -31,7 +31,7 @@ class Image_Publisher:
             through the constructor.
     """
 
-    def __init__(self, topic: str, node:Node, encoding: str = "bgr8", queue_size: int = 1):
+    def __init__(self, topic: str, node:Node, encoding: str = "infer", queue_size: int = 1):
         self.bridge = CvBridge()
         self.encoding = encoding
         self.node:Node = node
@@ -151,7 +151,7 @@ class VisionStack(Node):
             if verbose: # Create a display showing how each layer processes the image before it
                 try:
                     # when debugging we expect different image encodings (maybe there's an RGB layer, then BW, etc.)
-                    verbose_layer_pub = Image_Publisher(topic_name, self, encoding="infer")
+                    verbose_layer_pub = Image_Publisher(topic_name, self)
                     verbose_layer_pub.publish(processed_image)
                     ros_is_running = True
                 except:

--- a/vision_stack/VisionStack.py
+++ b/vision_stack/VisionStack.py
@@ -40,13 +40,54 @@ class Image_Publisher:
     def get_num_connections(self) -> int:
         return self.im_pub.get_subscription_count()
 
+    
+    # used to infer the encoding of an image
+    # useful when publishing different image encodings from same Image_Publisher instance
+    @staticmethod
+    def guess_ros_encoding(img: np.ndarray) -> str:
+        """
+        Guess the appropriate ROS image encoding string based on a NumPy image array.
+
+        Parameters:
+            img (np.ndarray): The input image as a NumPy array.
+
+        Returns:
+            str: A string representing the ROS-compatible image encoding.
+        """
+        if not isinstance(img, np.ndarray):
+            raise TypeError("Input must be a NumPy array.")
+
+        if img.dtype != np.uint8:
+            raise ValueError(f"Unsupported dtype: {img.dtype}. Only uint8 (8-bit) is supported.")
+
+        shape = img.shape
+
+        # Grayscale image (H, W)
+        if len(shape) == 2:
+            return "mono8"
+
+        # Color image (H, W, C)
+        if len(shape) == 3:
+            channels = shape[2]
+            if channels == 1:
+                return "mono8"
+            elif channels == 3:
+                return "bgr8"  # Assuming OpenCV-style (BGR)
+            elif channels == 4:
+                return "bgra8"
+            else:
+                raise ValueError(f"Unsupported number of channels: {channels}")
+        
+        raise ValueError(f"Unsupported image shape: {shape}")
+
     def publish(self, cv_image: np.ndarray):
         """
         Publishes an OpenCV image mat to the ROS topic. :class:`CvBridgeError`
         exceptions are caught and logged.
         """
         try:
-            image_message = self.bridge.cv2_to_imgmsg(cv_image, self.encoding)
+            encoding = self.encoding if self.encoding != "infer" else Image_Publisher.guess_ros_encoding(cv_image)
+            image_message = self.bridge.cv2_to_imgmsg(cv_image, encoding)
             self.im_pub.publish(image_message)
         except CvBridgeError as e:
             # Intentionally absorb CvBridge Errors
@@ -109,7 +150,8 @@ class VisionStack(Node):
 
             if verbose: # Create a display showing how each layer processes the image before it
                 try:
-                    verbose_layer_pub = Image_Publisher(topic_name, self)
+                    # when debugging we expect different image encodings (maybe there's an RGB layer, then BW, etc.)
+                    verbose_layer_pub = Image_Publisher(topic_name, self, encoding="infer")
                     verbose_layer_pub.publish(processed_image)
                     ros_is_running = True
                 except:

--- a/vision_stack/layers/BinThresholdingLayer.py
+++ b/vision_stack/layers/BinThresholdingLayer.py
@@ -10,7 +10,7 @@ class BinThresholdingLayer(PreprocessLayer):
 
         Parameters:
             low: lower threshold for binarization process. Must be between 0 and 255.
-            high: higher threshold of binarization process. Must be between 0 and 255 and greater than 255.
+            high: higher threshold of binarization process. Must be between 0 and 255 and greater than low.
         """
         if low < 0 or high > 255 or low > high:
             raise Exception(f"Threshold values are invalid:\nLow: {low}  High: {high}\nRequirements:\n- Low < High\n- Low > 0\n- High < 255")


### PR DESCRIPTION
### changes made

Fixed some typos in the readme and in one of the layer files.

The main change was adding a new static method `guess_ros_encoding` to the `Image_Publisher` class.

### why tho?

So the image publisher class converts cv2 imgs to ros imgs and publishes them. It's designed to work with a single encoding (stored in self.encoding).

The issue is that when running in verbose mode, the `VisionStack` class's `run` method uses `Image_Publisher` as if it works with multiple different encodings in one instance.

### code that im talking about (joe handsome)

VisionStack.py, line 152

```python
if verbose: # Create a display showing how each layer processes the image before it
    try:
        # when debugging we expect different image encodings (maybe there's an RGB layer, then BW, etc.)
        verbose_layer_pub = Image_Publisher(topic_name, self, encoding="infer")
        verbose_layer_pub.publish(processed_image)
        ros_is_running = True
```

The code above is called for each layer and each layer could return a different cv2 image encoding (maybe 1 is BW and another is RGB). `Image_Publisher` is being used as if it can accept different encodings!

### so how fix

VisionStack.py line 89

```python
encoding = self.encoding if self.encoding != "infer" else Image_Publisher.guess_ros_encoding(cv_image)
image_message = self.bridge.cv2_to_imgmsg(cv_image, encoding)

```

add an infer option: if publishing an image and encoding = infer, a new function will guess the cv2 image's encoding and pass it to the bridge.

### why do it this way

lowk i don't like stringly typed parameters but `cv2_to_imgmsg` also uses encoding this way. If encoding == "passthrough" it will try and use the cv2 images encoding

```
I didn't use passthrough because it gave me an error i didn't understand
```

### do it work tho??

i'm the best ever so yes!

I made a branch on the mil2 repo for testing [here](https://github.com/uf-mil/mil2/tree/joe_vision_stack_testing/src/subjugator/testing).

You can checkout that branch, run the code as specified in the readme. 
Run the code b4 changing the sub-module to see the error, then change the sub module to this branch to confirm it works