### PR TITLE
Minor Layer Mods

### DIFF
--- a/vision_stack/layers/NormalizationLayer.py
+++ b/vision_stack/layers/NormalizationLayer.py
@@ -33,7 +33,7 @@ class RobustScalingLayer(PreprocessLayer):
         """
         Normalizes the image by calculating the median and the IQR of all the pixels, then subtracting the median form the pixels and dividing by the IQR.
         """
-        super().__init__()
+        super().__init__("RobustScalingLayer")
     
     def process(self, image):
         median = np.median(image)

--- a/vision_stack/layers/UnderwaterEnhancementLayer.py
+++ b/vision_stack/layers/UnderwaterEnhancementLayer.py
@@ -9,6 +9,7 @@
 
 import os
 import torch
+from pathlib import Path
 from PIL import Image
 import torch
 import numpy as np
@@ -18,7 +19,7 @@ from datetime import datetime
 
 from .Layer import PreprocessLayer
 
-WEIGHTS_PATH = os.path.join(os.getcwd(), "vision_stack", "weights", 'model_best_2842.pth.tar')
+WEIGHTS_PATH = Path(os.path.abspath(__file__)).parent.parent / "weights" / "model_best_2842.pth.tar"
 
 class UnderWaterImageEnhancementLayer(PreprocessLayer):
     def __init__(self) -> None:


### PR DESCRIPTION
In the code review for another PR I made (https://github.com/uf-mil/vision_stack/pull/41#discussion_r2491128752), Daniel mentioned that small changes to the layer scripts can be made into a PR.

I'm guessing that's because the layer scripts are such a huge component, so it's better to separate something like that from my development of the test script to make it easier to track down bugs.

I made 2 small changes:

- Fixed a bug with accessing the weights file in the `UnderwaterEnhancementLayer.py` script. (Actually, Daniel might've made this change from my account when I was asking about VisionStack in the lab).
- Passed the layer name in during construction of the RobustScalingLayer in the `NormalizationLayer.py` script just so my publisher name logic in my other branch (https://github.com/uf-mil/vision_stack/pull/41#discussion_r2491128752) can create a proper name for this layer's publisher.